### PR TITLE
feat(service-activity): Close runners when cron job finishes

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -378,6 +378,7 @@ github.com/aws/aws-sdk-go v1.51.7 h1:RRjxHhx9RCjw5AhgpmmShq3F4JDlleSkyhYMQ2xUAe8
 github.com/aws/aws-sdk-go v1.51.7/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bearsh/hid v1.3.0 h1:GLNa8hvEzJxzQEEpheDUr2SivvH7iwTrJrDhFKutfX8=
 github.com/bearsh/hid v1.3.0/go.mod h1:KbQByg8WfPr92v7aaKAHTtZUEVG7e2XRpcF8+TopQv8=
 github.com/beevik/etree v1.3.0 h1:hQTc+pylzIKDb23yYprodCWWTt+ojFfUZyzU09a/hmU=
@@ -702,6 +703,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/pkg/serviceactivities/cronjob/cronjob.go
+++ b/pkg/serviceactivities/cronjob/cronjob.go
@@ -79,6 +79,12 @@ func (sa *ServiceActivity) Run(ctx context.Context) error {
 	// Wait for added jobs to finish
 	<-ctx2.Done()
 
+	// Close the job task
+	err2 := async.RunClose(ctx, job)
+	if err == nil {
+		err = err2
+	}
+
 	return err
 }
 

--- a/pkg/serviceactivities/cronjob/cronjob_test.go
+++ b/pkg/serviceactivities/cronjob/cronjob_test.go
@@ -4,20 +4,54 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/grevych/gobox/pkg/async"
+	"github.com/grevych/gobox/pkg/serviceactivities/cronjobtest"
 	"gotest.tools/v3/assert"
 )
 
 func TestServiceActivity_RunAndClose(t *testing.T) {
+	/*
+
+		Explanation:
+
+			       0s                  1s                  2s                 3s
+			       |-------------------|-------------------|------------------|
+
+		Job
+		Schedule
+			                           < ~500 ms >
+			                           ^
+			                           First job exec
+
+			                                                < ~500 ms >
+			                                                ^
+			                                                Second job exec
+
+		Test
+		Execution
+			             <------------   ~2000 ms   ------------>
+			             ^
+			             Test sleep
+			                                                     .......
+			                                                     ^     ^
+			                                                     |     |
+			                                                     |     |
+			                                                     |
+			                                                     |     End of second job exec
+			                                                     |
+
+			                                                     Close service activity
+	*/
 	var cronjobErr error
 	wg := sync.WaitGroup{}
-	counter := 0
+	counter := atomic.Int32{}
 	newJob := func() Job {
 		var job async.Func = func(ctx context.Context) error {
-			counter += 1
+			counter.Add(1)
 			time.Sleep(500 * time.Millisecond)
 			return nil
 		}
@@ -31,15 +65,79 @@ func TestServiceActivity_RunAndClose(t *testing.T) {
 		cronjobErr = cronjobSvc.Run(context.Background())
 	}()
 
-	time.Sleep(2500 * time.Millisecond)
+	time.Sleep(2000 * time.Millisecond)
 	cronjobSvc.Close(context.Background())
 
 	wg.Wait()
 
-	// Job was executed twice since we force to wait for the
-	// last job schedule.
-	assert.Assert(t, counter == 2)
+	// Since the job was scheduled twice, we strictly wait for the
+	// last job task execution.
+	assert.Equal(t, counter.Load(), int32(2))
 	assert.NilError(t, cronjobErr)
+}
+
+func TestServiceActivity_RuntAndCancelContext(t *testing.T) {
+	/*
+
+		Explanation:
+
+			       0s                  1s                  2s                 3s
+		           |-------------------|-------------------|------------------|
+
+		Job
+		Schedule
+			                           < ~500 ms >
+			                           ^
+			                           First job exec
+
+			                                                < ~500 ms >
+			                                                ^
+			                                                Second job exec
+
+		Test
+		Execution
+			             <------------   ~2000 ms   ------------>
+			             ^
+			             Test sleep
+			                                                     .......
+			                                                     ^     ^
+			                                                     |     |
+			                                                     |     |
+			                                                     |
+			                                                     |     End of second job exec
+			                                                     |
+
+			                                                     Context canceled
+	*/
+	var cronjobErr error
+	wg := sync.WaitGroup{}
+	counter := atomic.Int32{}
+	newJob := func() Job {
+		var job async.Func = func(ctx context.Context) error {
+			counter.Add(1)
+			time.Sleep(500 * time.Millisecond)
+			return nil
+		}
+		return job
+	}
+	cronjobSvc := New(newJob, "@every 1s")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cronjobErr = cronjobSvc.Run(ctx)
+	}()
+
+	time.Sleep(2000 * time.Millisecond)
+	cancel()
+
+	wg.Wait()
+
+	// Since the job was scheduled twice, we strictly wait for the
+	// last job task execution.
+	assert.Equal(t, counter.Load(), int32(2))
+	assert.ErrorContains(t, cronjobErr, "context canceled")
 }
 
 func TestServiceActivity_RunWithError(t *testing.T) {
@@ -64,34 +162,46 @@ func TestServiceActivity_RunWithError(t *testing.T) {
 	assert.ErrorContains(t, cronjobErr, "cronjob with error")
 }
 
-func TestServiceActivity_RuntAndCancelContext(t *testing.T) {
+func TestServiceActivity_RunAndCloseWithErrorOnClose(t *testing.T) {
 	var cronjobErr error
 	wg := sync.WaitGroup{}
-	counter := 0
 	newJob := func() Job {
-		var job async.Func = func(ctx context.Context) error {
-			counter += 1
-			time.Sleep(500 * time.Millisecond)
-			return nil
-		}
-		return job
+		return &cronjobtest.RunnerWithCloseError{}
 	}
 	cronjobSvc := New(newJob, "@every 1s")
-	ctx, cancel := context.WithCancel(context.Background())
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		cronjobErr = cronjobSvc.Run(ctx)
+		cronjobErr = cronjobSvc.Run(context.Background())
 	}()
 
-	time.Sleep(2500 * time.Millisecond)
-	cancel()
+	time.Sleep(1000 * time.Millisecond)
+	cronjobSvc.Close(context.Background())
 
 	wg.Wait()
 
-	// Job was executed twice since we force to wait for the
-	// last job schedule.
-	assert.Assert(t, counter == 2)
-	assert.ErrorContains(t, cronjobErr, "context canceled")
+	assert.ErrorContains(t, cronjobErr, "error while closing runner")
+}
+
+func TestServiceActivity_RunAndCloseWithErrors(t *testing.T) {
+	var cronjobErr error
+	wg := sync.WaitGroup{}
+	newJob := func() Job {
+		return &cronjobtest.RunnerWithErrors{}
+	}
+	cronjobSvc := New(newJob, "@every 1s")
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cronjobErr = cronjobSvc.Run(context.Background())
+	}()
+
+	time.Sleep(1000 * time.Millisecond)
+	cronjobSvc.Close(context.Background())
+
+	wg.Wait()
+
+	assert.ErrorContains(t, cronjobErr, "error while running runner")
 }

--- a/pkg/serviceactivities/cronjobtest/cronjobtest.go
+++ b/pkg/serviceactivities/cronjobtest/cronjobtest.go
@@ -1,0 +1,30 @@
+package cronjobtest
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type RunnerWithCloseError struct {
+}
+
+func (r *RunnerWithCloseError) Run(ctx context.Context) error {
+	time.Sleep(300 * time.Millisecond)
+	return nil
+}
+
+func (r *RunnerWithCloseError) Close(ctx context.Context) error {
+	return errors.New("error while closing runner")
+}
+
+type RunnerWithErrors struct {
+}
+
+func (r *RunnerWithErrors) Run(ctx context.Context) error {
+	return errors.New("error while running runner")
+}
+
+func (r *RunnerWithErrors) Close(ctx context.Context) error {
+	return errors.New("error while closing runner")
+}


### PR DESCRIPTION
Allows the cron job service activity to call  any `Close` action on the underlying task when the job finishes its execution. A few tests were improved as well in the same package.